### PR TITLE
New script easing a config-to-docs run

### DIFF
--- a/ctd.sh
+++ b/ctd.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# If not already made, make this script executable by running sudo chmod +x ctd.sh
+
+printf "\nConfig-To-Docs update script\n"
+printf "\nThis script assumes that you have the git clone directory of core and docs on the same file hierarchy level as you have the cloned config-to-docs clone from where this script runs !!\n"
+printf "\nPlease ensure before running this script, that you have switched to the correct branch in core AND you have created and switched to a pushable target branch in docs !!\n\n"
+
+CORE="../core"
+DOCS="../docs"
+
+if [ ! -d "$CORE" ]; then
+  printf "\ncore repro not found - exiting\n"
+  exit
+fi
+
+if [ ! -d "$DOCS" ]; then
+  printf "\ndocs repro not found - exiting\n"
+  exit
+fi
+
+# mandatory prompt for starting the export
+read -p "Do you want to start exporting changes (y/N)? " -r -e answer
+(echo "$answer" | grep -iq "^y") && changes="y" || changes="n"
+
+if [ ! "$changes" = "y" ]; then
+  exit
+fi
+
+printf "\nExporting: config.sample.php\n"
+php convert.php config:convert-adoc \
+  --input-file=$CORE/config/config.sample.php \
+  --output-file=$DOCS/modules/admin_manual/pages/configuration/server/config_sample_php_parameters.adoc
+printf "DONE\n"
+
+printf "\nExporting: config.apps.sample.php\n"
+php convert.php config:convert-adoc \
+  --input-file=$CORE/config/config.apps.sample.php \
+  --output-file=$DOCS/modules/admin_manual/pages/configuration/server/config_apps_sample_php_parameters.adoc
+printf "DONE\n\n"
+
+printf "\nPlease go now to docs and check/push the changes made\n\n"

--- a/ctd.sh
+++ b/ctd.sh
@@ -10,12 +10,12 @@ CORE="../core"
 DOCS="../docs"
 
 if [ ! -d "$CORE" ]; then
-  printf "\ncore repro not found - exiting\n"
+  printf "\ncore repo not found - exiting\n"
   exit
 fi
 
 if [ ! -d "$DOCS" ]; then
-  printf "\ndocs repro not found - exiting\n"
+  printf "\ndocs repo not found - exiting\n"
   exit
 fi
 


### PR DESCRIPTION
This is a script easing the `config-to-docs` run.
I was too lazy always copy/past the scrip from readme.md ...

Now you just run this script with `./ctd.sh` (make it executable before with `sudo chmod +x ctd.sh`).

Manually tested and works great.
