### PR TITLE
ci: pin actions/checkout and setup-php to SHA for org security policy

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -15,10 +15,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Setup PHP with PECL extension
-      uses: shivammathur/setup-php@v2
+      uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
       with:
         php-version: '7.4'
         extensions: imagick, redis


### PR DESCRIPTION
## Summary

- Pins `actions/checkout` to `34e114876b0b11c390a56381ad16ebd13914f8d5` (v4.3.1)
- Pins `shivammathur/setup-php` to `accd6127cb78bee3e8082180cb391013d204ef9f` (2.37.0)
- Complies with the org's SHA-pinning policy for GitHub Actions

## Test plan

- [ ] Verify CI workflow runs successfully after the pin changes
- [ ] Confirm pinned SHAs correspond to the expected action releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)